### PR TITLE
Fixing: TypeError [ERR_INVALID_ARG_TYPE] (Windows 10)

### DIFF
--- a/consumer/package.json
+++ b/consumer/package.json
@@ -8,7 +8,7 @@
     "react-dom": "^16.12.0",
     "react-router": "latest",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "3.3.0",
+    "react-scripts": "^3.4.0",
     "spectre.css": "^0.5.8",
     "prop-types": "latest"
   },
@@ -41,7 +41,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",
-    "babel-eslint": "^10.0.3",
+    "babel-eslint": "^10.1.0",
     "eslint": "^6.8.0",
     "eslint-config-react-app": "^5.1.0",
     "eslint-plugin-flowtype": "^3.13.0",


### PR DESCRIPTION
Fixing: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined