### PR TITLE
Step 4 - Indicating contracts located at Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ describe("Pact Verification", () => {
             provider: "ProductService",
             providerVersion: "1.0.0",
             pactUrls: [
-                path.resolve(__dirname, '../../consumer/pacts/frontendwebsite-productservice.json')
+                path.resolve(__dirname, '../pacts/frontendwebsite-productservice.json')
             ]
         };
 


### PR DESCRIPTION
The initial part of the Step 4 suggest copying the consumer contracts to the provider folder, however the Provider verification test points out the consumer folder.

This change makes the code point out to the copied file.