### PR TITLE
chore(ci): prevent duplicate ci triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: Build
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Triggering on all 'push' and 'pull_request' events will result in duplicated CI runs in PRs (due to both conditions being met).

Instead, trigger only on pushes to `master`, or updates to PRs targetting `master`.